### PR TITLE
2: Removed extra parameter from data table form

### DIFF
--- a/config/routes.yesodroutes
+++ b/config/routes.yesodroutes
@@ -19,7 +19,7 @@
 
 /data-table/#TableId DataTableR GET
 
-/data-table-form/#TableId/#ColumnId DataTableFormR GET POST
+/data-table-form/#ColumnId DataTableFormR GET POST
 
 /data-team/#TeamId DataTeamR GET
 

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -171,7 +171,7 @@ instance Yesod App where
     isAuthorized MetadataFormR _ = isAuthenticated
     isAuthorized DataHomeR _ = isAuthenticated
     isAuthorized (DataTableR _) _ = isAuthenticated
-    isAuthorized (DataTableFormR _ _) _ = isAuthenticated
+    isAuthorized (DataTableFormR _) _ = isAuthenticated
     isAuthorized (DataTeamR _) _ = isAuthenticated
     isAuthorized DataTeamFormR _ = isAuthenticated
 

--- a/src/Handler/DataTable.hs
+++ b/src/Handler/DataTable.hs
@@ -25,7 +25,7 @@ getDataTableR tableId = do
             <ul>
                 $forall Entity columnId column <- columns
                     <li>
-                        <a href=@{DataTableFormR tableId columnId}>#{columnName column}
+                        <a href=@{DataTableFormR columnId}>#{columnName column}
                         $maybe description <- columnDescription column
                             <p>#{description}
                         $maybe example <- columnExample column


### PR DESCRIPTION
Closes #2 
Instead of passing in both tableId and columnId, use the columnId to query for the tableId.