### PR TITLE
26: Changed forms to use Form type synonym

### DIFF
--- a/src/Handler/ColumnEdit.hs
+++ b/src/Handler/ColumnEdit.hs
@@ -24,7 +24,7 @@ data ColumnData = ColumnData
     }
   deriving Show
 
-columnForm ::  Html -> MForm Handler (FormResult ColumnData, Widget)
+columnForm :: Form ColumnData
 columnForm = renderDivs $ ColumnData
     <$> aopt textField "Description" Nothing
     <*> pure Nothing -- aopt textField "Datatype (leave empty)" Nothing

--- a/src/Handler/TableCreate.hs
+++ b/src/Handler/TableCreate.hs
@@ -22,7 +22,7 @@ data TableData = TableData
   deriving Show
 
 
-tableForm :: Html -> MForm Handler (FormResult TableData, Widget)
+tableForm :: Form TableData
 tableForm = renderDivs $ TableData
     <$> areq textField "Name*" Nothing
     <*> aopt textField "Description" Nothing

--- a/src/Handler/TeamCreate.hs
+++ b/src/Handler/TeamCreate.hs
@@ -23,7 +23,7 @@ data TeamData = TeamData
   deriving Show
 
 
-teamForm :: Html -> MForm Handler (FormResult TeamData, Widget)
+teamForm :: Form TeamData
 teamForm = renderDivs $ TeamData
     <$> areq textField "Name*" Nothing
     <*> aopt textField "Description" Nothing


### PR DESCRIPTION
Closes #26
Instead of the old signature `Html -> MForm Handler (FormResult a, Widget)`