### PR TITLE
34: Add identifiers and descriptions to the pages

### DIFF
--- a/src/Handler/ColumnEdit.hs
+++ b/src/Handler/ColumnEdit.hs
@@ -10,9 +10,12 @@ module Handler.ColumnEdit where
 import Import
 import qualified Data.Text as T
 
+
 getColumnEditR :: TableId -> ColumnId -> Handler Html
 getColumnEditR tableId columnId = do
     (widget, enctype) <- generateFormPost columnForm
+    column <- runDB $ getJust columnId
+    table <- runDB $ getJust tableId
     defaultLayout $ do
         setTitle . toHtml $ T.pack "Update column"
         $(widgetFile "column-edit")

--- a/src/Handler/DataTeamTableList.hs
+++ b/src/Handler/DataTeamTableList.hs
@@ -16,4 +16,5 @@ import Import
 getDataTeamTableListR :: TeamId -> Handler Html
 getDataTeamTableListR teamId = do
     validTableOptions <- runDB $ selectList [TableTeamId ==. Nothing] []
+    team <- runDB $ getJust teamId
     defaultLayout $(widgetFile "data-team-table-list")

--- a/templates/column-edit.hamlet
+++ b/templates/column-edit.hamlet
@@ -1,3 +1,6 @@
+<h1>Edit column: #{columnName column}
+<h2>on table: #{tableName table}
+
 <form method=post action=@{TableR tableId $ ColumnEditR columnId} enctype=#{enctype}>
     ^{widget}
     <button>Submit

--- a/templates/data-team-table-list.hamlet
+++ b/templates/data-team-table-list.hamlet
@@ -1,3 +1,6 @@
+<h1>Claim a table for your team
+<h3>Team name: #{teamName team}
+
 $forall Entity tableId table <- validTableOptions
     <form action=@{TeamR teamId $ DataTeamAddTableR tableId} method="POST">
         <input type="submit" value="add #{tableName table}">

--- a/templates/table-create.hamlet
+++ b/templates/table-create.hamlet
@@ -1,3 +1,6 @@
+<h1>Create a new table!
+<p>You will become the owner of this table. You will also be able to add columns later.
+
 <form method=post action=@{TablesR TableCreateR} enctype=#{enctype}>
     ^{widget}
     <button>Submit

--- a/templates/table-detail.hamlet
+++ b/templates/table-detail.hamlet
@@ -1,3 +1,5 @@
+<h1>#{tableName table}
+
 $maybe Entity teamId team <- maybeTeamEntity
     <a href=@{TeamR teamId TeamDetailR}>#{teamName team}
 $nothing

--- a/templates/team-create.hamlet
+++ b/templates/team-create.hamlet
@@ -1,3 +1,6 @@
+<h1>Create a new team
+<p>The team will be used to manage tables. More features such as users belonging to a team on their way!
+
 <form method=post action=@{TeamsR TeamCreateR} enctype=#{enctype}>
     ^{widget}
     <button>Submit


### PR DESCRIPTION
Closes #34 

Specifically, any route with a value passed in like tableId or teamId now has that teams name listed so you know whose page you're on.

Also added a couple of descriptors on the create pages so you roughly know the purpose of the thing you're creating, and the implications.