### PR TITLE
44: Add titles to all routes

### DIFF
--- a/src/Handler/ColumnEdit.hs
+++ b/src/Handler/ColumnEdit.hs
@@ -8,8 +8,6 @@
 module Handler.ColumnEdit where
 
 import Import
-import qualified Data.Text as T
-
 
 getColumnEditR :: TableId -> ColumnId -> Handler Html
 getColumnEditR tableId columnId = do
@@ -17,7 +15,7 @@ getColumnEditR tableId columnId = do
     column <- runDB $ getJust columnId
     table <- runDB $ getJust tableId
     defaultLayout $ do
-        setTitle . toHtml $ T.pack "Update column"
+        setTitle . toHtml $ "Update column " <> columnName column
         $(widgetFile "column-edit")
     
 data ColumnData = ColumnData

--- a/src/Handler/DataTeamTableList.hs
+++ b/src/Handler/DataTeamTableList.hs
@@ -17,4 +17,6 @@ getDataTeamTableListR :: TeamId -> Handler Html
 getDataTeamTableListR teamId = do
     validTableOptions <- runDB $ selectList [TableTeamId ==. Nothing] []
     team <- runDB $ getJust teamId
-    defaultLayout $(widgetFile "data-team-table-list")
+    defaultLayout $ do
+        setTitle . toHtml $ "Add table to " <> teamName team
+        $(widgetFile "data-team-table-list")

--- a/src/Handler/TableCreate.hs
+++ b/src/Handler/TableCreate.hs
@@ -9,11 +9,14 @@ module Handler.TableCreate where
 
 import Import
 import Data.Maybe (fromJust)
+import qualified Data.Text as T
 
 getTableCreateR :: Handler Html
 getTableCreateR = do
     (widget, enctype) <- generateFormPost tableForm
-    defaultLayout $(widgetFile "table-create")
+    defaultLayout $ do
+        setTitle . toHtml $ T.pack "Create new table"
+        $(widgetFile "table-create")
    
 data TableData = TableData
     { tableDataName :: Text

--- a/src/Handler/TableDetail.hs
+++ b/src/Handler/TableDetail.hs
@@ -20,4 +20,6 @@ getTableDetailR tableId = do
     maybeTeamEntity <- case tableTeamId table of
         Nothing -> pure Nothing
         Just teamId -> runDB $ getEntity teamId
-    defaultLayout $(widgetFile "table-detail")
+    defaultLayout $ do
+        setTitle . toHtml $ tableName table
+        $(widgetFile "table-detail")

--- a/src/Handler/TableList.hs
+++ b/src/Handler/TableList.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Handler.TableList where
 
@@ -29,4 +30,6 @@ getTableListR = do
                 ( table ^. TableId
                 , table ^. TableName
                 )
-    defaultLayout $(widgetFile "table-list")
+    defaultLayout $ do
+        setTitle . toHtml $ ("All tables" :: Text)
+        $(widgetFile "table-list")

--- a/src/Handler/TeamCreate.hs
+++ b/src/Handler/TeamCreate.hs
@@ -12,7 +12,9 @@ import Import
 getTeamCreateR :: Handler Html
 getTeamCreateR = do
     (widget, enctype) <- generateFormPost teamForm
-    defaultLayout $(widgetFile "team-create")
+    defaultLayout $ do
+        setTitle . toHtml $ ("Create a team" :: Text)
+        $(widgetFile "team-create")
    
 data TeamData = TeamData
     { teamDataName :: Text

--- a/src/Handler/TeamDetail.hs
+++ b/src/Handler/TeamDetail.hs
@@ -9,8 +9,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
-
-
 module Handler.TeamDetail where
 
 import Import

--- a/src/Handler/TeamDetail.hs
+++ b/src/Handler/TeamDetail.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
+
+
 module Handler.TeamDetail where
 
 import Import
@@ -17,4 +19,6 @@ getTeamDetailR :: TeamId -> Handler Html
 getTeamDetailR teamId = do
     team <- runDB $ getJust teamId
     tables <- runDB $ selectList [TableTeamId ==. Just teamId] []
-    defaultLayout $(widgetFile "team-detail")
+    defaultLayout $ do
+        setTitle . toHtml $ "Update column " <> teamName team
+        $(widgetFile "team-detail")


### PR DESCRIPTION
Closes #44 

Added titles to all the routes, either with the name of the value the route describes (like `team name`), or just the route itself (like `Create a team`)