### PR TITLE
28: Fill fields with defaults

### DIFF
--- a/src/Handler/ColumnEdit.hs
+++ b/src/Handler/ColumnEdit.hs
@@ -11,33 +11,36 @@ import Import
 
 getColumnEditR :: TableId -> ColumnId -> Handler Html
 getColumnEditR tableId columnId = do
-    (widget, enctype) <- generateFormPost columnForm
     column <- runDB $ getJust columnId
     table <- runDB $ getJust tableId
+    (widget, enctype) <- generateFormPost $ columnForm $ Just column
     defaultLayout $ do
         setTitle . toHtml $ "Update column " <> columnName column
         $(widgetFile "column-edit")
     
 data ColumnData = ColumnData
-    { columnDataDescription :: Maybe Text
+    { columnDataName :: Text
+    , columnDataDescription :: Maybe Text
     , columnDataDatatype :: Maybe Datatype
     , columnDataExample :: Maybe Text
     }
   deriving Show
 
-columnForm :: Form ColumnData
-columnForm = renderDivs $ ColumnData
-    <$> aopt textField "Description" Nothing
+columnForm :: Maybe Column -> Form ColumnData
+columnForm column = renderDivs $ ColumnData
+    <$> areq textField "Name" (columnName <$> column)
+    <*> aopt textField "Description" (columnDescription <$> column)
     <*> pure Nothing -- aopt textField "Datatype (leave empty)" Nothing
-    <*> aopt textField "Example" Nothing
+    <*> aopt textField "Example" (columnExample <$> column)
 
 postColumnEditR :: TableId -> ColumnId -> Handler ()
 postColumnEditR tableId columnId = do
-    ((result, _), _) <- runFormPost columnForm
+    ((result, _), _) <- runFormPost $ columnForm Nothing
     case result of
         FormSuccess columnData -> do
             runDB $ update columnId
-                [ ColumnDescription =. columnDataDescription columnData
+                [ ColumnName =. columnDataName columnData
+                , ColumnDescription =. columnDataDescription columnData
                 , ColumnDatatype =. columnDataDatatype columnData
                 , ColumnExample =. columnDataExample columnData
                 ]

--- a/src/Handler/TableEdit.hs
+++ b/src/Handler/TableEdit.hs
@@ -11,8 +11,8 @@ import Import
 
 getTableEditR :: TableId -> Handler Html
 getTableEditR tableId = do
-    (widget, enctype) <- generateFormPost tableForm
     table <- runDB $ getJust tableId
+    (widget, enctype) <- generateFormPost $ tableForm $ Just table
     defaultLayout $ do
         setTitle . toHtml $ "Update table " <> tableName table
         $(widgetFile "table-edit")
@@ -23,14 +23,14 @@ data TableData = TableData
     }
   deriving Show
 
-tableForm :: Form TableData
-tableForm = renderDivs $ TableData
-    <$> areq textField "Name" Nothing
-    <*> aopt textField "Description" Nothing
+tableForm :: Maybe Table -> Form TableData
+tableForm table = renderDivs $ TableData
+    <$> areq textField "Name" (tableName <$> table)
+    <*> aopt textField "Description" (tableDescription <$> table)
 
 postTableEditR :: TableId -> Handler ()
 postTableEditR tableId = do
-    ((result, _), _) <- runFormPost tableForm
+    ((result, _), _) <- runFormPost $ tableForm Nothing
     case result of
         FormSuccess tableData -> do
             runDB $ update tableId


### PR DESCRIPTION
Closes #28 

For all the edit tables, include the current data so users can "edit" instead of overwriting.