### PR TITLE
103: Host keter on aws

### DIFF
--- a/config/keter.yml
+++ b/config/keter.yml
@@ -1,6 +1,5 @@
 # After you've edited this file, remove the following line to allow
 # `yesod keter` to build your bundle.
-user-edited: false
 
 # A Keter app is composed of 1 or more stanzas. The main stanza will define our
 # web application. See the Keter documentation for more information on
@@ -25,7 +24,7 @@ stanzas:
       # You can specify one or more hostnames for your application to respond
       # to. The primary hostname will be used for generating your application
       # root.
-      - www.data-dictionary.com
+      - ec2-18-144-155-182.us-west-1.compute.amazonaws.com
 
     # Enable to force Keter to redirect to https
     # Can be added to any stanza
@@ -34,7 +33,7 @@ stanzas:
   # Static files.
   - type: static-files
     hosts:
-      - static.data-dictionary.com
+      - static.ec2-18-144-155-182.us-west-1.compute.amazonaws.com
     root: ../static
 
     # Uncomment to turn on directory listings.
@@ -44,9 +43,9 @@ stanzas:
   - type: redirect
 
     hosts:
-      - data-dictionary.com
+      - ec2-18-144-155-182.us-west-1.compute.amazonaws.com
     actions:
-      - host: www.data-dictionary.com
+      - host: ec2-18-144-155-182.us-west-1.compute.amazonaws.com
         # secure: false
         # port: 80
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,7 @@
 
 static-dir:     "_env:YESOD_STATIC_DIR:static"
 host:           "_env:YESOD_HOST:*4" # any IPv4 host
-port:           "_env:YESOD_PORT:3000" # NB: The port `yesod devel` uses is distinct from this value. Set the `yesod devel` port from the command line.
+port:           "_env:PORT:80" # NB: The port `yesod devel` uses is distinct from this value. Set the `yesod devel` port from the command line.
 ip-from-header: "_env:YESOD_IP_FROM_HEADER:false"
 
 # Default behavior: determine the application root from the request headers.


### PR DESCRIPTION
Closes #103 

Successfully hosted

Process:
```
2. Run `yesod keter`
3. ssh -i ~/Downloads/admin.pem ubuntu@"public.ipv4"
2.5 `sudo chown $USER /opt/keter/incoming`
3. scp -i ~/Downloads/admin.pem data-dictionary.keter ubuntu@"public.ipv4":/opt/keter/incoming/
4.  scp -i ~/Downloads/admin.pem /path/to/keter-binary ubuntu@"public.ipv4":/opt/keter/incoming/
6. move keter binary to /opt/keter/bin
6. `sudo apt-get update && sudo apt-get install postgresql`
7. Create and enter into file:```
```# /etc/systemd/system/keter.service
[Unit]
Description=Keter
After=network.service

[Service]
Type=simple
ExecStart=/opt/keter/bin/keter /opt/keter/etc/keter-config.yaml

[Install]
WantedBy=multi-user.target```
```
```
root: ..
# /opt/keter/etc/keter-config.yaml
listeners:
    # HTTP
    - host: "!6" # Listen on all IPv4 hosts
      port: 80 # Could be used to modify port
```
8.sudo systemctl enable keter
9. sudo systemctl start keter