### PR TITLE
112: Replace user idents

### DIFF
--- a/src/Handler/TablePermissions.hs
+++ b/src/Handler/TablePermissions.hs
@@ -14,7 +14,7 @@ module Handler.TablePermissions where
 import Import
 
 data PermissionData = PermissionData 
-    { permissionDataUser :: UserId
+    { permissionDataProfileId :: ProfileId
     , permissionDataType :: PermissionType
     }
 
@@ -24,7 +24,7 @@ permissionForm = renderDivs $ PermissionData
     <*> areq (selectFieldList pTuples) "which perm?" Nothing
       where
           pTuples = [("Own" :: Text, Own), ("Edit", Edit), ("View", View)]
-          uTuples = optionsPersistKey ([] :: [Filter User]) [] userIdent
+          uTuples = optionsPersistKey ([] :: [Filter Profile]) [] profileName
 
 getTablePermissionsR :: TableId -> Handler Html
 getTablePermissionsR tableId = do
@@ -39,8 +39,9 @@ postTablePermissionsR tableId = do
     ((result, _), _) <- runFormPost permissionForm
     case result of
         FormSuccess permissionData -> do
+            profile <- runDB $ getJust $ permissionDataProfileId permissionData
             _ <- runDB $ insert $ Permission
-                (permissionDataUser permissionData)
+                (profileUserId profile)
                 tableId
                 (permissionDataType permissionData)
             redirect $ TableR tableId TableDetailR

--- a/src/Handler/TablePermissions.hs
+++ b/src/Handler/TablePermissions.hs
@@ -39,7 +39,7 @@ postTablePermissionsR tableId = do
     ((result, _), _) <- runFormPost permissionForm
     case result of
         FormSuccess permissionData -> do
-            profile <- runDB $ getJust $ permissionDataProfileId permissionData
+            profile <- runDB $ get404 $ permissionDataProfileId permissionData
             _ <- runDB $ insert $ Permission
                 (profileUserId profile)
                 tableId

--- a/templates/table-detail.hamlet
+++ b/templates/table-detail.hamlet
@@ -12,6 +12,7 @@ $if permissionPermissionType perm >= Own
 
 $if permissionPermissionType perm >= Edit
     <a href=@{TableR tableId TableEditR}>Edit the table
+    <a href=@{TableR tableId TablePermissionsR}>Grant permissions
 
 $if permissionPermissionType perm >= Own
     <form action=@{TableR tableId TableDeleteR} method="POST">


### PR DESCRIPTION
Closes #112 

Fixed the select tag showing user ids granted by google auth before, now it shows the profile name. Also uses get404 instead of getJust to protect the site from errors. look at #114 for more details.