### PR TITLE
131: Fix dont exist page

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -298,37 +298,31 @@ isAuthenticated = do
 
 userPermittedTable :: TableId -> PermissionType -> Handler AuthResult
 userPermittedTable tableId permissionType = do
-    muid <- maybeAuthId
-    case muid of
-        Nothing -> return $ Unauthorized "You must login to access this page"
-        Just uid -> do
-            mPermissionRow <- runDB $ getBy $ UniquePair uid tableId
-            return $ case mPermissionRow of
-                Nothing -> Unauthorized $ T.pack $ "You do not have the correct permissions to " ++ show permissionType ++ " this table."
-                Just (Entity _ permissionRow) -> 
-                    if permissionPermissionType permissionRow >= permissionType 
-                    then Authorized 
-                    else Unauthorized $ T.pack $ "You do not have the correct permissions to " ++ show permissionType ++ " this table."
+    uid <- requireAuthId
+    mPermissionRow <- runDB $ getBy $ UniquePair uid tableId
+    return $ case mPermissionRow of
+        Nothing -> Unauthorized $ T.pack $ "You do not have the correct permissions to " ++ show permissionType ++ " this table."
+        Just (Entity _ permissionRow) -> 
+            if permissionPermissionType permissionRow >= permissionType 
+            then Authorized 
+            else Unauthorized $ T.pack $ "You do not have the correct permissions to " ++ show permissionType ++ " this table."
 
 
 userProfileNotExists :: Handler AuthResult
 userProfileNotExists = do
     userId <- requireAuthId
-    mprofile <- runDB $ selectFirst [ProfileUserId ==. userId] []
+    mprofile <- runDB $ getBy $ UniqueProfile userId
     return $ case mprofile of
         Nothing -> Authorized
         Just (Entity _ profile) -> Unauthorized $ T.pack "Profile for " ++ profileName profile ++ " already exists."
 
 userPermittedProfile :: ProfileId -> Handler AuthResult
 userPermittedProfile profileId = do
-    (userId, _) <- requireAuthPair
-    mprofile <- runDB $ get profileId
-    return $ case mprofile of
-        Nothing -> Unauthorized $ T.pack ""
-        Just profile -> 
-            if userId == profileUserId profile 
-              then Authorized 
-              else Unauthorized $ T.pack ""
+    userId <- requireAuthId
+    profile <- runDB $ get404 profileId
+    return $ if userId == profileUserId profile 
+               then Authorized 
+               else Unauthorized ("" :: Text)
 
 instance YesodAuthPersist App
 

--- a/src/Handler/ColumnCreateEdit.hs
+++ b/src/Handler/ColumnCreateEdit.hs
@@ -51,8 +51,8 @@ columnForm column = renderDivs $ ColumnData
 
 getColumnEditR :: TableId -> ColumnId -> Handler Html
 getColumnEditR tableId columnId = do
-    column <- runDB $ getJust columnId
-    table <- runDB $ getJust tableId
+    column <- runDB $ get404 columnId
+    table <- runDB $ get404 tableId
     (widget, enctype) <- generateFormPost $ columnForm $ Just column
     defaultLayout $ do
         setTitle . toHtml $ "Update column " <> columnName column
@@ -76,7 +76,7 @@ postColumnEditR tableId columnId = do
 getColumnCreateR :: TableId -> Handler Html
 getColumnCreateR tableId = do
     (widget, enctype) <- generateFormPost $ columnForm Nothing
-    table <- runDB $ getJust tableId
+    table <- runDB $ get404 tableId
     defaultLayout $ do
         setTitle . toHtml $ "Add column to " <> tableName table
         $(widgetFile "column-create")

--- a/src/Handler/ProfileCreateEdit.hs
+++ b/src/Handler/ProfileCreateEdit.hs
@@ -72,7 +72,7 @@ postProfileCreateR = do
 
 getProfileEditR :: ProfileId -> Handler Html
 getProfileEditR profileId = do
-    profile <- runDB $ getJust profileId
+    profile <- runDB $ get404 profileId
     (widget, enctype) <- generateFormPost $ profileForm $ Just profile
     defaultLayout $ do
         setTitle . toHtml $ "Edit " <> profileName profile <> "'s profile"

--- a/src/Handler/ProfileDetail.hs
+++ b/src/Handler/ProfileDetail.hs
@@ -17,7 +17,7 @@ data ProfileData = ProfileData
 
 getProfileDetailR :: ProfileId -> Handler Html
 getProfileDetailR profileId = do
-    profile <- runDB $ getJust profileId
+    profile <- runDB $ get404 profileId
     muid <- maybeAuthId
     let canEdit = case muid of
             Nothing -> False

--- a/src/Handler/TableCreateEdit.hs
+++ b/src/Handler/TableCreateEdit.hs
@@ -9,7 +9,6 @@ module Handler.TableCreateEdit where
 
 import Import
 
-import Data.Maybe (fromJust)
 import qualified Data.Text as T
 
 data TableData = TableData
@@ -55,9 +54,9 @@ postTableCreateR = do
                 (tableDataName tableData)
                 Nothing
                 (tableDataDescription tableData)
-            muid <- maybeAuthId
+            uid <- requireAuthId
             _ <- runDB $ insert $ Permission
-                (fromJust muid)
+                uid
                 tableId
                 Own
             redirect $ TableR tableId TableDetailR
@@ -66,7 +65,7 @@ postTableCreateR = do
 
 getTableEditR :: TableId -> Handler Html
 getTableEditR tableId = do
-    table <- runDB $ getJust tableId
+    table <- runDB $ get404 tableId
     (widget, enctype) <- generateFormPost $ tableForm $ Just table
     defaultLayout $ do
         setTitle . toHtml $ "Update table " <> tableName table

--- a/src/Handler/TableDetail.hs
+++ b/src/Handler/TableDetail.hs
@@ -18,13 +18,12 @@ import Data.Maybe (fromJust)
 getTableDetailR :: TableId -> Handler Html
 getTableDetailR tableId = do
     columns <- runDB $ selectList [ColumnTableId ==. tableId] []
-    table <- runDB $ getJust tableId
+    table <- runDB $ get404 tableId
     maybeTeamEntity <- case tableTeamId table of
         Nothing -> pure Nothing
         Just teamId -> runDB $ getEntity teamId
-    muid <- maybeAuthId
-    mperm <- runDB $ getBy $ UniquePair (fromJust muid) tableId
-    let (Entity _ perm) = fromJust mperm
+    uid <- requireAuthId
+    Entity _ perm <- runDB $ getBy404 $ UniquePair uid tableId
     defaultLayout $ do
         setTitle . toHtml $ tableName table
         $(widgetFile "table-detail")

--- a/src/Handler/TableList.hs
+++ b/src/Handler/TableList.hs
@@ -16,16 +16,14 @@ import Import
 import qualified Database.Esqueleto as E
 import           Database.Esqueleto      ((^.))
 
-import Data.Maybe (fromJust)
-
 getTableListR :: Handler Html
 getTableListR = do
-    muid <- maybeAuthId
+    uid <- requireAuthId
     tables <- runDB 
         $ E.select
         $ E.from $ \(table `E.InnerJoin` permission) -> do
             E.on $ table ^. TableId E.==. permission ^. PermissionTableId
-            E.where_ $ permission ^. PermissionUserId E.==. E.val (fromJust muid)
+            E.where_ $ permission ^. PermissionUserId E.==. E.val uid
             return
                 ( table ^. TableId
                 , table ^. TableName

--- a/src/Handler/TablePermissions.hs
+++ b/src/Handler/TablePermissions.hs
@@ -44,7 +44,7 @@ permissionForm = renderDivs $ PermissionData
 
 getTablePermissionsR :: TableId -> Handler Html
 getTablePermissionsR tableId = do
-    table <- runDB $ getJust tableId
+    table <- runDB $ get404 tableId
     (widget, enctype) <- generateFormPost permissionForm
     defaultLayout $ do
         setTitle . toHtml $ "Add permissions for table: " <> tableName table

--- a/src/Handler/TeamCreateEdit.hs
+++ b/src/Handler/TeamCreateEdit.hs
@@ -80,7 +80,7 @@ postTeamCreateR = do
 
 getTeamEditR :: TeamId -> Handler Html
 getTeamEditR teamId = do
-    team <- runDB $ getJust teamId
+    team <- runDB $ get404 teamId
     (widget, enctype) <- generateFormPost $ teamForm $ Just team
     defaultLayout $ do
         setTitle . toHtml $ "Edit team " <> teamName team

--- a/src/Handler/TeamDetail.hs
+++ b/src/Handler/TeamDetail.hs
@@ -15,7 +15,7 @@ import Import
 
 getTeamDetailR :: TeamId -> Handler Html
 getTeamDetailR teamId = do
-    team <- runDB $ getJust teamId
+    team <- runDB $ get404 teamId
     tables <- runDB $ selectList [TableTeamId ==. Just teamId] []
     profiles <- runDB $ selectList [ProfileTeamId ==. Just teamId] []
     defaultLayout $ do


### PR DESCRIPTION
Closes #131 

Fixed the internal server error messages by adding a 404 if things don't exist (like if you try editing the URL to something that doesn't exist). Originally I assumed that they existed because of the nature of the handler. 

Maybe in the future, I will move the 404 option to outside the handler and into auth.